### PR TITLE
Fixed error messages on login and registration.

### DIFF
--- a/Software/smart-charger/src/pages/Login/Login.jsx
+++ b/Software/smart-charger/src/pages/Login/Login.jsx
@@ -33,7 +33,7 @@ export const Login = () => {
       setRole(jwtData.roleId);
       setIsLoggedIn(true);
     } else {
-      setError(res.message);
+      setError(res.error);
     }
   };
 

--- a/Software/smart-charger/src/pages/Register/Register.jsx
+++ b/Software/smart-charger/src/pages/Register/Register.jsx
@@ -53,7 +53,7 @@ export const Register = () => {
         password: password,
       });
       if (!res.success) {
-        setError(res.message);
+        setError(res.error);
       } else {
         await loginUser({
           email: email,
@@ -71,7 +71,7 @@ export const Register = () => {
       setRole(jwtData.roleId);
       setIsLoggedIn(true);
     } else {
-      setError(res.message);
+      setError(res.error);
     }
   };
 


### PR DESCRIPTION
When login or register is unsuccessful, the app displays the message that the backend sends, when it should display the error.
That is fixed in this hotfix.